### PR TITLE
Add backgroud colour to logo image for browsers render <hr> elements behind floats

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,10 @@
 <body class="h-100">
 <div class="container min-vh-100">
     <div class="row">
-        <div class="col-12 p-4 ">
-            <img src="assets/images/phpsa-logo-colour-med.png" width="400" height="317" alt="PHP South Africa Logo" class="float-left mx-4 mb-2">
+        <div class="col-12 p-4">
+            <div class="float-left" style="background-color: aliceblue">
+                <img src="assets/images/phpsa-logo-colour-med.png" width="400" height="317" alt="PHP South Africa Logo" class="mx-4 mb-2" >
+            </div>
 
             <h1 class="">PHP South Africa Meetup</h1>
             <p>Welcome!</p>


### PR DESCRIPTION
This hotfix addresses reports that chrome renders the first \<hr\> element through our logo.

Example:
![image](https://user-images.githubusercontent.com/2180195/114692697-224ac200-9d19-11eb-8fcb-c8c6825322db.png)

It simply sets a background colour to the logo to hide this rendering problem